### PR TITLE
Spherical padding and faster tests

### DIFF
--- a/src/xarray_regrid/methods/conservative.py
+++ b/src/xarray_regrid/methods/conservative.py
@@ -72,8 +72,10 @@ def conservative_regrid(
 
     # Make sure the regridding coordinates are sorted
     coord_names = [coord for coord in target_ds.coords if coord in data.coords]
-    target_ds_sorted = target_ds.sortby(coord_names)
-    data = data.sortby(list(coord_names))
+    target_ds_sorted = target_ds.copy()
+    for coord_name in coord_names:
+        target_ds_sorted = utils.ensure_monotonic(target_ds_sorted, coord_name)
+        data = utils.ensure_monotonic(data, coord_name)
     coords = {name: target_ds_sorted[name] for name in coord_names}
 
     regridded_data = utils.call_on_dataset(

--- a/src/xarray_regrid/methods/conservative.py
+++ b/src/xarray_regrid/methods/conservative.py
@@ -72,7 +72,7 @@ def conservative_regrid(
 
     # Make sure the regridding coordinates are sorted
     coord_names = [coord for coord in target_ds.coords if coord in data.coords]
-    target_ds_sorted = target_ds.copy()
+    target_ds_sorted = xr.Dataset(coords=target_ds.coords)
     for coord_name in coord_names:
         target_ds_sorted = utils.ensure_monotonic(target_ds_sorted, coord_name)
         data = utils.ensure_monotonic(data, coord_name)

--- a/src/xarray_regrid/methods/conservative.py
+++ b/src/xarray_regrid/methods/conservative.py
@@ -66,7 +66,7 @@ def conservative_regrid(
     # Attempt to infer the latitude coordinate
     if latitude_coord is None:
         for coord in data.coords:
-            if str(coord).lower().startswith("lat"):
+            if str(coord).lower() in ["lat", "latitude"]:
                 latitude_coord = coord
                 break
 

--- a/src/xarray_regrid/utils.py
+++ b/src/xarray_regrid/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 from dataclasses import dataclass
 from typing import Any, overload
 
@@ -75,7 +75,7 @@ def create_lat_lon_coords(grid: Grid) -> tuple[np.ndarray, np.ndarray]:
             grid.south, grid.north + grid.resolution_lat, grid.resolution_lat
         )
 
-    if np.remainder((grid.north - grid.south), grid.resolution_lat) > 0:
+    if np.remainder((grid.east - grid.west), grid.resolution_lat) > 0:
         lon_coords = np.arange(grid.west, grid.east, grid.resolution_lon)
     else:
         lon_coords = np.arange(
@@ -235,3 +235,127 @@ def call_on_dataset(
         return next(iter(result.data_vars.values())).rename(obj.name)
 
     return result
+
+
+def format_for_regrid(
+    obj: xr.DataArray | xr.Dataset, target: xr.Dataset
+) -> xr.DataArray | xr.Dataset:
+    """Apply any pre-formatting to the input dataset to prepare for regridding.
+    Currently handles padding of spherical geometry if appropriate coordinate names
+    can be inferred containing 'lat' and 'lon'.
+    """
+    lat_coord = None
+    lon_coord = None
+
+    for coord in obj.coords.keys():
+        if str(coord).lower().startswith("lat"):
+            lat_coord = coord
+        elif str(coord).lower().startswith("lon"):
+            lon_coord = coord
+
+    if lon_coord is not None or lat_coord is not None:
+        obj = format_spherical(obj, target, lat_coord, lon_coord)
+
+    return obj
+
+
+def format_spherical(
+    obj: xr.DataArray | xr.Dataset,
+    target: xr.Dataset,
+    lat_coord: Hashable,
+    lon_coord: Hashable,
+) -> xr.DataArray | xr.Dataset:
+    """Infer whether a lat/lon source grid represents a global domain and
+    automatically apply spherical padding to improve edge effects.
+
+    For longitude, shift the coordinate to line up with the target values, then
+    add a single wraparound padding column if the domain is global and the east
+    or west edges of the target lie outside the source grid centers.
+
+    For latitude, add a single value at each pole computed as the mean of the last
+    row for global source grids where the first or last point lie equatorward of 90.
+    """
+
+    orig_chunksizes = obj.chunksizes
+
+    # If the source coord fully covers the target, don't modify them
+    if lat_coord and not coord_is_covered(obj, target, lat_coord):
+        obj = obj.sortby(lat_coord)
+        target = target.sortby(lat_coord)
+
+        # Only pad if global but don't have edge values directly at poles
+        polar_lat = 90
+        dy = obj[lat_coord].diff(lat_coord).max().values
+
+        # South pole
+        if dy - polar_lat >= obj[lat_coord][0] > -polar_lat:
+            south_pole = obj.isel({lat_coord: 0})
+            # This should match the Pole="all" option of ESMF
+            if lon_coord is not None:
+                south_pole = south_pole.mean(lon_coord)
+            obj = xr.concat([south_pole, obj], dim=lat_coord)
+            obj[lat_coord].values[0] = -polar_lat
+
+        # North pole
+        if polar_lat - dy <= obj[lat_coord][-1] < polar_lat:
+            north_pole = obj.isel({lat_coord: -1})
+            if lon_coord is not None:
+                north_pole = north_pole.mean(lon_coord)
+            obj = xr.concat([obj, north_pole], dim=lat_coord)
+            obj[lat_coord].values[-1] = polar_lat
+
+        # Coerce back to a single chunk if that's what was passed
+        if len(orig_chunksizes.get(lat_coord, [])) == 1:
+            obj = obj.chunk({lat_coord: -1})
+
+    if lon_coord and not coord_is_covered(obj, target, lon_coord):
+        obj = obj.sortby(lon_coord)
+        target = target.sortby(lon_coord)
+
+        target_lon = target[lon_coord].values
+        # Find a wrap point outside of the left and right bounds of the target
+        # This ensures we have coverage on the target and handles global > regional
+        wrap_point = (target_lon[-1] + target_lon[0] + 360) / 2
+        lon = obj[lon_coord].values
+        lon = np.where(lon < wrap_point - 360, lon + 360, lon)
+        lon = np.where(lon > wrap_point, lon - 360, lon)
+        obj[lon_coord].values[:] = lon
+
+        # Shift operations can produce duplicates
+        # Simplest solution is to drop them and add back when padding
+        obj = obj.sortby(lon_coord).drop_duplicates(lon_coord)
+
+        # Only pad if domain is global in lon
+        dx_s = obj[lon_coord].diff(lon_coord).max().values
+        dx_t = target[lon_coord].diff(lon_coord).max().values
+        is_global_lon = obj[lon_coord].max() - obj[lon_coord].min() >= 360 - dx_s
+
+        if is_global_lon:
+            left_pad = (obj[lon_coord][0] - target[lon_coord][0] + dx_t / 2) / dx_s
+            right_pad = (target[lon_coord][-1] - obj[lon_coord][-1] + dx_t / 2) / dx_s
+            left_pad = int(np.ceil(np.max([left_pad, 0])))
+            right_pad = int(np.ceil(np.max([right_pad, 0])))
+            lon = obj[lon_coord].values
+            obj = obj.pad(
+                {lon_coord: (left_pad, right_pad)}, mode="wrap", keep_attrs=True
+            )
+            if left_pad:
+                obj[lon_coord].values[:left_pad] = lon[-left_pad:] - 360
+            if right_pad:
+                obj[lon_coord].values[-right_pad:] = lon[:right_pad] + 360
+
+            # Coerce back to a single chunk if that's what was passed
+            if len(orig_chunksizes.get(lon_coord, [])) == 1:
+                obj = obj.chunk({lon_coord: -1})
+
+    return obj
+
+
+def coord_is_covered(
+    obj: xr.DataArray | xr.Dataset, target: xr.Dataset, coord: Hashable
+) -> bool:
+    """Check if the source coord fully covers the target coord."""
+    pad = target[coord].diff(coord).max().values
+    left_covered = obj[coord].min() <= target[coord].min() - pad
+    right_covered = obj[coord].max() >= target[coord].max() + pad
+    return bool(left_covered.item() and right_covered.item())

--- a/src/xarray_regrid/utils.py
+++ b/src/xarray_regrid/utils.py
@@ -385,13 +385,9 @@ def ensure_monotonic(
     """Ensure that an object has monotonically increasing indexes for a
     given coordinate. Only sort and drop duplicates if needed because this
     requires reindexing which can be expensive."""
-    is_sorted = (obj.coords[coord].diff(coord) >= 0).all().compute().item()
-    if not is_sorted:
+    if not obj.indexes[coord].is_monotonic_increasing:
         obj = obj.sortby(coord)
-    has_duplicates = (
-        np.unique(obj.coords[coord].values).size < obj.coords[coord].values.size
-    )
-    if has_duplicates:
+    if not obj.indexes[coord].is_unique:
         obj = obj.drop_duplicates(coord)
     return obj
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,178 @@
+import xarray as xr
+
+import xarray_regrid
+from xarray_regrid.utils import format_for_regrid
+
+
+def test_covered():
+    dx_source = 2
+    source = xarray_regrid.Grid(
+        north=90,
+        east=360,
+        south=-90,
+        west=0,
+        resolution_lat=dx_source,
+        resolution_lon=dx_source,
+    ).create_regridding_dataset()
+
+    dx_target = 1
+    target = xarray_regrid.Grid(
+        north=80,
+        east=350,
+        south=-80,
+        west=10,
+        resolution_lat=dx_target,
+        resolution_lon=dx_target,
+    ).create_regridding_dataset()
+
+    formatted = format_for_regrid(source, target)
+
+    # Formatting utils shouldn't modify this one at all
+    xr.testing.assert_equal(source, formatted)
+
+
+def test_no_edges():
+    dx_source = 2
+    source = xarray_regrid.Grid(
+        north=90 - dx_source / 2,
+        east=360 - dx_source / 2,
+        south=-90 + dx_source / 2,
+        west=0 + dx_source / 2,
+        resolution_lat=dx_source,
+        resolution_lon=dx_source,
+    ).create_regridding_dataset()
+
+    dx_target = 1
+    target = xarray_regrid.Grid(
+        north=90,
+        east=360,
+        south=-90,
+        west=0,
+        resolution_lat=dx_target,
+        resolution_lon=dx_target,
+    ).create_regridding_dataset()
+
+    formatted = format_for_regrid(source, target)
+
+    # Should add wraparound and polar padding rows/columns
+    assert formatted.latitude[0] == -90
+    assert formatted.latitude[-1] == 90
+    assert formatted.longitude[0] == -1
+    assert formatted.longitude[-1] == 361
+    assert (formatted.longitude.diff("longitude") == 2).all()
+
+
+def test_360_to_180():
+    dx_source = 2
+    source = xarray_regrid.Grid(
+        north=90,
+        east=360,
+        south=-90,
+        west=0,
+        resolution_lat=dx_source,
+        resolution_lon=dx_source,
+    ).create_regridding_dataset()
+
+    dx_target = 1
+    target = xarray_regrid.Grid(
+        north=90,
+        east=180,
+        south=-90,
+        west=-180,
+        resolution_lat=dx_target,
+        resolution_lon=dx_target,
+    ).create_regridding_dataset()
+
+    formatted = format_for_regrid(source, target)
+
+    # Should produce a shift to target plus wraparound padding
+    assert formatted.longitude[0] == -182
+    assert formatted.longitude[-1] == 182
+    assert (formatted.longitude.diff("longitude") == 2).all()
+
+
+def test_180_to_360():
+    dx_source = 2
+    source = xarray_regrid.Grid(
+        north=90,
+        east=180,
+        south=-90,
+        west=-180,
+        resolution_lat=dx_source,
+        resolution_lon=dx_source,
+    ).create_regridding_dataset()
+
+    dx_target = 1
+    target = xarray_regrid.Grid(
+        north=90,
+        east=360,
+        south=-90,
+        west=0,
+        resolution_lat=dx_target,
+        resolution_lon=dx_target,
+    ).create_regridding_dataset()
+
+    formatted = format_for_regrid(source, target)
+
+    # Should produce a shift to target plus wraparound padding
+    assert formatted.longitude[0] == -2
+    assert formatted.longitude[-1] == 362
+    assert (formatted.longitude.diff("longitude") == 2).all()
+
+
+def test_0_to_360():
+    dx_source = 2
+    source = xarray_regrid.Grid(
+        north=90,
+        east=0,
+        south=-90,
+        west=-360,
+        resolution_lat=dx_source,
+        resolution_lon=dx_source,
+    ).create_regridding_dataset()
+
+    dx_target = 1
+    target = xarray_regrid.Grid(
+        north=90,
+        east=360,
+        south=-90,
+        west=0,
+        resolution_lat=dx_target,
+        resolution_lon=dx_target,
+    ).create_regridding_dataset()
+
+    formatted = format_for_regrid(source, target)
+
+    # Should produce a shift to target plus wraparound padding
+    assert formatted.longitude[0] == -2
+    assert formatted.longitude[-1] == 362
+    assert (formatted.longitude.diff("longitude") == 2).all()
+
+
+def test_global_to_local_shift():
+    dx_source = 2
+    source = xarray_regrid.Grid(
+        north=90,
+        east=180,
+        south=-90,
+        west=-180,
+        resolution_lat=dx_source,
+        resolution_lon=dx_source,
+    ).create_regridding_dataset()
+
+    dx_target = 1
+    target = xarray_regrid.Grid(
+        north=90,
+        east=300,
+        south=-90,
+        west=270,
+        resolution_lat=dx_target,
+        resolution_lon=dx_target,
+    ).create_regridding_dataset()
+
+    formatted = format_for_regrid(source, target)
+
+    # Should produce a shift to cover the target range
+    assert formatted.longitude.min() <= 270
+    assert formatted.longitude.max() >= 300
+    assert (formatted.longitude.diff("longitude") == 2).all()


### PR DESCRIPTION
- [x] closes #8 
- [x] closes #9 

## Spherical padding

This makes an initial attempt at building in some automatic logic for better handling the boundaries of a spherical domain with appropriate padding, as well as shifting the longitude source grid to match the target as needed.

## Faster tests

Made some modifications and general cleanup of the existing tests. Mainly making the datasets dask-backed so the regridding functions are lazy for all the attribute checks. Also got rid of some unneeded copies, compute calls, etc. Tests run in about 17 seconds now.

With the addition of the spherical padding logic I was also able to remove some aspects of the tests where we avoided checking for good matches at the boundaries.

## Conservative NaN tracking

I did some benchmarking and the version of NaN tracking where we track independently across non-grid dimensions as well doesn't actually have much of a run-time penalty. Therefore I went ahead and made this small change. The only issue is that it can induce a very large memory penalty if the input data isn't chunked, because the weights arrays can become huge if they are broadcast with all the other input dimensions. I added a note to the docstring about this but perhaps we want a more formal warning, or to explicitly add some chunking in certain cases?

## TODO / open questions

- [x] tests added
- [x] fix typing
- [x] add examples to docstrings
- [ ] add args to make the padding behavior configurable?
