### PR TITLE
Fix attributes being dropped in certain circumstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+Fixed:
+ - Attributes are now properly preserved when updating coordinates during pre-formatting for regridding ([#54](https://github.com/xarray-contrib/xarray-regrid/pull/54)).
+
 
 ## 0.4.0 (2024-09-26)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,11 @@ authors:
   - given-names: Sam
     family-names: Levang
     affiliation: Salient Predictions
+  - given-names: Ben
+    family-names: Mares
+    orcid: 'https://orcid.org/0000-0002-1036-0793'
+    affiliation: Tensorial (EI Bernard Mares)
+    email: services-xarray-regrid@tensorial.com
 
 repository-code: 'https://github.com/EXCITED-CO2/xarray-regrid'
 keywords:

--- a/src/xarray_regrid/utils.py
+++ b/src/xarray_regrid/utils.py
@@ -316,7 +316,7 @@ def format_lat(
     if dy - polar_lat >= obj.coords[lat_coord].values[0] > -polar_lat:
         south_pole = obj.isel({lat_coord: 0})
         if lon_coord is not None:
-            south_pole = south_pole.mean(lon_coord)
+            south_pole = south_pole.mean(lon_coord, keep_attrs=True)
         obj = xr.concat([south_pole, obj], dim=lat_coord)  # type: ignore
         lat_vals = np.concatenate([[-polar_lat], lat_vals])
 
@@ -324,7 +324,7 @@ def format_lat(
     if polar_lat - dy <= obj.coords[lat_coord].values[-1] < polar_lat:
         north_pole = obj.isel({lat_coord: -1})
         if lon_coord is not None:
-            north_pole = north_pole.mean(lon_coord)
+            north_pole = north_pole.mean(lon_coord, keep_attrs=True)
         obj = xr.concat([obj, north_pole], dim=lat_coord)  # type: ignore
         lat_vals = np.concatenate([lat_vals, [polar_lat]])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import numpy as np
+import xarray as xr
+
+from xarray_regrid.utils import format_lat
+
+
+def test_format_lat():
+    lat_vals = np.arange(-89.5, 89.5 + 1, 1)
+    lon_vals = np.arange(-179.5, 179.5 + 1, 1)
+    x_vals = np.broadcast_to(lat_vals, (len(lon_vals), len(lat_vals)))
+    ds = xr.Dataset(
+        data_vars={"x": (("lon", "lat"), x_vals)},
+        coords={"lat": lat_vals, "lon": lon_vals},
+        attrs={"foo": "bar"},
+    )
+    ds.lat.attrs["is"] = "coord"
+    ds.x.attrs["is"] = "data"
+
+    formatted = format_lat(ds, ds, {"lat": "lat", "lon": "lon"})
+    # Check that lat has been extended to include poles
+    assert formatted.lat.values[0] == -90
+    assert formatted.lat.values[-1] == 90
+    # Check that data has been extrapolated to include poles
+    assert (formatted.x.isel(lat=0) == -89.5).all()
+    assert (formatted.x.isel(lat=-1) == 89.5).all()
+    # Check that attrs have been preserved
+    assert formatted.attrs["foo"] == "bar"
+    assert formatted.lat.attrs["is"] == "coord"
+    assert formatted.x.attrs["is"] == "data"


### PR DESCRIPTION
Whenever `format_lat` is triggered and extrapolates data to the poles, the attributes were being dropped.