### PR TITLE
Fix three latent bugs in Grid construction and mode regridders

### DIFF
--- a/src/xarray_regrid/regrid.py
+++ b/src/xarray_regrid/regrid.py
@@ -164,10 +164,10 @@ class Regridder:
 
         if isinstance(self._obj, xr.Dataset):
             msg = (
-                "The 'most common value' regridder is not implemented for\n",
+                "The 'most common value' regridder is not implemented for\n"
                 "xarray.Dataset, as it requires specifying the expected labels.\n"
                 "Please select only a single variable (as DataArray),\n"
-                " and regrid it separately.",
+                " and regrid it separately."
             )
             raise ValueError(msg)
 
@@ -216,10 +216,10 @@ class Regridder:
 
         if isinstance(self._obj, xr.Dataset):
             msg = (
-                "The 'least common value' regridder is not implemented for\n",
+                "The 'least common value' regridder is not implemented for\n"
                 "xarray.Dataset, as it requires specifying the expected labels.\n"
                 "Please select only a single variable (as DataArray),\n"
-                " and regrid it separately.",
+                " and regrid it separately."
             )
             raise ValueError(msg)
 

--- a/src/xarray_regrid/utils.py
+++ b/src/xarray_regrid/utils.py
@@ -31,11 +31,10 @@ class Grid:
         msg = None
         if self.south > self.north:
             msg = (
-                "Value of north bound is greater than south bound."
+                "Value of south bound is greater than north bound."
                 "\nPlease check the bounds input."
             )
-            pass
-        if self.west > self.east:
+        elif self.west > self.east:
             msg = (
                 "Value of west bound is greater than east bound."
                 "\nPlease check the bounds input."
@@ -80,7 +79,7 @@ def create_lat_lon_coords(grid: Grid) -> tuple[np.ndarray, np.ndarray]:
             grid.south, grid.north + grid.resolution_lat, grid.resolution_lat
         )
 
-    if np.remainder((grid.east - grid.west), grid.resolution_lat) > 0:
+    if np.remainder((grid.east - grid.west), grid.resolution_lon) > 0:
         lon_coords = np.arange(grid.west, grid.east, grid.resolution_lon)
     else:
         lon_coords = np.arange(


### PR DESCRIPTION
Three small, independent bug fixes spotted while reading the code.

1. `utils.create_lat_lon_coords` — the longitude-span check uses `resolution_lat` instead of `resolution_lon`, so non-square grids can overshoot `east`.
2. `Grid.__post_init__` — the `south > north` branch reports the wrong bound name, and the two checks use `if`/`if` so the second overwrites the first. Switched to `elif` and fixed the wording. Drops a stray `pass`.
3. `regrid.most_common` / `regrid.least_common` — the Dataset-input error message has a stray comma making `msg` a tuple, so `ValueError(msg)` renders unreadably.
