### PR TITLE
perf: axis-factored cubic interp on rectilinear grids (~15× faster)

### DIFF
--- a/src/xarray_regrid/methods/interp.py
+++ b/src/xarray_regrid/methods/interp.py
@@ -37,16 +37,41 @@ def interp_regrid(
         Regridded input dataset
     """
     coord_names = set(target_ds.coords).intersection(set(data.coords))
-    coords = {name: target_ds[name] for name in coord_names}
     coord_attrs = {coord: data[coord].attrs for coord in coord_names}
 
-    interped = data.interp(
-        coords=coords,
-        method=method,
-    )
+    # For cubic on rectilinear (1D-coord) targets, apply interp one axis at
+    # a time rather than through xarray's multi-coord dispatch. The single
+    # multi-coord call routes through scipy.interpolate.interpn's N-D
+    # tensor-product B-spline path (``make_ndbspl`` plus an iterative
+    # solver — ~250 ms on a 360x720 -> 120x240 global workload). Applying
+    # a 1D cubic spline along each axis in turn gives essentially the same
+    # output (relative RMS ~1e-5) at ~1/15 the cost.
+    if method == "cubic" and _all_1d_coords(data, target_ds, coord_names):
+        interped = data
+        for name in sorted(coord_names):
+            interped = interped.interp({name: target_ds[name]}, method="cubic")
+    else:
+        coords = {name: target_ds[name] for name in coord_names}
+        interped = data.interp(coords=coords, method=method)
 
     # xarray's interp drops some of the coordinate's attributes (e.g. long_name)
     for coord in coord_names:
         interped[coord].attrs = coord_attrs[coord]
 
     return interped
+
+
+def _all_1d_coords(
+    data: xr.DataArray | xr.Dataset,
+    target_ds: xr.Dataset,
+    coord_names: set,
+) -> bool:
+    """True when every regrid coord is 1D on both source and target.
+
+    Gates the axis-factored cubic path: factoring requires separable axes,
+    which is only guaranteed for rectilinear coordinates.
+    """
+    for name in coord_names:
+        if data[name].ndim != 1 or target_ds[name].ndim != 1:
+            return False
+    return True


### PR DESCRIPTION
> ⚠️ **Work in progress** — Not ready to review
## Summary

\`xr.interp(method=\"cubic\")\` with multiple coords routes through \`scipy.interpolate.interpn\`, which builds an N-D tensor-product B-spline via \`make_ndbspl\` plus an iterative \`gcrotmk\` solver. For a global 360×720 → 120×240 workload that's ~260 ms — about 15× the cost of the corresponding \`linear\` or \`nearest\` call, and it scales poorly.

On rectilinear targets the axes are separable, so applying the same \`xr.interp(method=\"cubic\")\` one axis at a time gives essentially identical output at ~1/15 the cost. This PR adds that factored path inside \`methods/interp.interp_regrid\`, gated on all-1D coordinates. Curvilinear targets (2D coord arrays) still go through the existing N-D path.

No new dependencies — \`scipy\` is already a hard dep, and the factored path calls the same public \`xr.interp\` API, just routed onto a different scipy kernel (\`CubicSpline\` per axis instead of \`make_ndbspl\`).

## Reproduce

Copy-paste into a terminal with \`xarray-regrid\` installed editable from this branch:

\`\`\`python
\"\"\"Compare N-D cubic (current) vs factored 1D cubic (this PR) on a global
rect lat/lon grid. No arguments; prints wall times and numerical diff.\"\"\"
import statistics, time
import numpy as np, xarray as xr


def rect_source(ny=360, nx=720, nt=4, seed=0):
    lon = np.linspace(-180, 180, nx, endpoint=False) + 180 / nx
    lat = np.linspace(-90, 90, ny, endpoint=False) + 90 / ny
    rng = np.random.default_rng(seed)
    return xr.DataArray(
        rng.standard_normal((nt, ny, nx)),
        dims=(\"time\", \"latitude\", \"longitude\"),
        coords={\"time\": np.arange(nt), \"latitude\": lat, \"longitude\": lon},
        name=\"var\",
    )


def rect_target(ny=120, nx=240):
    lon = np.linspace(-180, 180, nx, endpoint=False) + 180 / nx
    lat = np.linspace(-90, 90, ny, endpoint=False) + 90 / ny
    return xr.Dataset(coords={\"latitude\": lat, \"longitude\": lon})


def nd_cubic(src, tgt):
    return src.interp(latitude=tgt.latitude, longitude=tgt.longitude, method=\"cubic\")


def factored_cubic(src, tgt):
    step = src.interp(latitude=tgt.latitude, method=\"cubic\")
    return step.interp(longitude=tgt.longitude, method=\"cubic\")


src, tgt = rect_source(), rect_target()
nd_cubic(src, tgt); factored_cubic(src, tgt)  # warm

def median(fn, n=3):
    s = [time.perf_counter() for _ in range(n)]
    for i in range(n):
        t0 = time.perf_counter(); fn(); s[i] = time.perf_counter() - t0
    return statistics.median(s)

t_nd = median(lambda: nd_cubic(src, tgt))
t_fac = median(lambda: factored_cubic(src, tgt))
print(f\"N-D cubic (current):      {t_nd * 1000:7.1f} ms\")
print(f\"factored 1D-cubic:        {t_fac * 1000:7.1f} ms\")
print(f\"speedup:                  {t_nd / t_fac:.1f}x\")

out_nd = nd_cubic(src, tgt).values
out_fac = factored_cubic(src, tgt).values.transpose(*range(out_nd.ndim))
rms = np.sqrt(np.nanmean((out_nd - out_fac) ** 2))
print()
print(f\"max abs diff: {np.nanmax(np.abs(out_nd - out_fac)):.3e}\")
print(f\"relative RMS: {rms / np.sqrt(np.nanmean(out_nd ** 2)):.3e}\")
\`\`\`

## Measured

Two runs on the same machine (macOS arm64 / Python 3.12):

\`\`\`
N-D cubic (current):        261.6 ms          N-D cubic (current):        260.2 ms
factored 1D-cubic:           16.6 ms          factored 1D-cubic:           15.2 ms
speedup:                  15.7x               speedup:                  17.1x

max abs diff: 1.093e-03                       max abs diff: 1.093e-03
relative RMS: 1.027e-05                       relative RMS: 1.027e-05
\`\`\`

## Numerical difference

The two paths are not bit-identical — sequential 1D cubic splines and N-D tensor-product B-splines use subtly different boundary handling. On this workload:

- max abs diff: **1.093e-03** (against max |value| of 4.21 — i.e. ~0.026 % peak)
- relative RMS: **1.03e-05**

This is well within any defensible error bound for cubic interpolation on a 0.5° grid (whose own discretisation error dominates), but it **is** a visible behaviour change, so I'm opening as a draft to get maintainer agreement that the speedup is worth the noise-level output shift before adding tests.

## Tests

All 71 existing tests pass on this branch (1 skipped, 1 xfailed — unchanged from main). I have **not** added a direct factored-vs-N-D correctness test yet — I want to know whether you'd prefer:

1. An \`allclose\` test with a documented tolerance (\`rtol=1e-4\`), or
2. A conditional test that exercises both paths and asserts the factored output agrees with the N-D output at a tight-but-finite tolerance, or
3. A new-feature test for a known analytic function (e.g. \`cos(lat) * sin(lon)\`) where both paths should match the analytic value within the grid's quadrature floor.

Happy to add whichever you think is right before de-drafting.

## Scope / open questions

1. **Only cubic** — \`linear\` and \`nearest\` aren't touched. Their multi-coord xr.interp path is already near-optimal (~20 ms and ~16 ms on this workload respectively) and 1D-factoring them doesn't give a meaningful speedup.
2. **Only rectilinear** — the check \`_all_1d_coords\` gates on source and target each having 1D coord arrays. Curvilinear (2D coord arrays) still use the N-D path, which is correct since they aren't axis-separable.
3. **Coordinate ordering** — iterated via \`sorted(coord_names)\` for determinism. The tensor-product result is independent of axis order for clean (unpadded) inputs, but boundary conditions can differ subtly. Happy to pick a different ordering (e.g. source dim order) if that's preferred.
4. **Dask** — not benchmarked on dask-backed inputs. The N-D spline's weight construction might already be amortised across chunks, so the factored win could be smaller there. Happy to add a dask case before de-drafting if you want.

Let me know what you'd like changed and I'll iterate.